### PR TITLE
Update lambda function handler name

### DIFF
--- a/doc_source/batch_cwet.md
+++ b/doc_source/batch_cwet.md
@@ -27,7 +27,7 @@ This tutorial assumes that you have a working compute environment and job queue 
    ```
    import json
    
-   def handler(event, context):
+   def lambda_handler(event, context):
        if event["source"] != "aws.batch":
           raise ValueError("Function only supports input from events with a source type of: aws.batch")
           


### PR DESCRIPTION
When you create a LambdaFunction using the AWS Admin Console, the default value of python's handler is lambda_function.lambda_handler

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
