### PR TITLE
Update example-job-definitions.md

### DIFF
--- a/doc_source/example-job-definitions.md
+++ b/doc_source/example-job-definitions.md
@@ -48,6 +48,7 @@ For more information, see [Parameters](job_definition_parameters.md#parameters)\
 {
     "jobDefinitionName": "ffmpeg_parameters",
     "type": "container",
+    "parameters": {"codec": "mp4"},
     "containerProperties": {
         "image": "my_repo/ffmpeg",
         "vcpus": 2,
@@ -62,7 +63,6 @@ For more information, see [Parameters](job_definition_parameters.md#parameters)\
             "Ref::outputfile"
         ],
         "jobRoleArn": "arn:aws:iam::012345678910:role/ECSTask-S3FullAccess",
-        "parameters": {"codec": "mp4"},
         "user": "nobody"
     }
 }


### PR DESCRIPTION
This example needs correcting, 'parameters' are not valid within a 'containerProperties' object.

Job Definition Parameters - Parameters - https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
