### PR TITLE
Fixed error with print-color Batch example Dockerfile.

### DIFF
--- a/doc_source/array_index_example.md
+++ b/doc_source/array_index_example.md
@@ -49,7 +49,7 @@ The `LINE` variable is set to the `AWS_BATCH_JOB_ARRAY_INDEX` \+ 1 because the a
    FROM busybox
    COPY print-color.sh /tmp/print-color.sh
    COPY colors.txt /tmp/colors.txt
-   RUN chmod +x /tmp/colors.sh
+   RUN chmod +x /tmp/print-color.sh
    ENTRYPOINT /tmp/print-color.sh
    ```
 


### PR DESCRIPTION
https://github.com/awsdocs/aws-batch-user-guide/issues/16

Fixed incorrect filename being looked for in Batch Dockerfile for print color example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
