### PR TITLE
docs: correct containerProperties for containerDefinitions

### DIFF
--- a/doc_source/specifying-sensitive-data-parameters.md
+++ b/doc_source/specifying-sensitive-data-parameters.md
@@ -58,7 +58,7 @@ The following is a snippet of a task definition showing the format when referenc
 
 ```
 {
-  "containerDefinitions": [{
+  "containerProperties": [{
     "secrets": [{
       "name": "environment_variable_name",
       "valueFrom": "arn:aws:ssm:region:aws_account_id:parameter/parameter_name"
@@ -78,7 +78,7 @@ The following is a snippet of a task definition showing the format when referenc
 
 ```
 {
-  "containerDefinitions": [{
+  "containerProperties": [{
     "logConfiguration": [{
       "logDriver": "fluentd",
       "options": {


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

ContainerDefinitions is not part of the API, I think thats copied from the ECS documentation, its actually ContainerProperties see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html#cfn-batch-jobdefinition-containerproperties