### PR TITLE
Remove ARM constraint

### DIFF
--- a/doc_source/fargate.md
+++ b/doc_source/fargate.md
@@ -18,7 +18,6 @@ However, we recommend that you use Amazon EC2 if your jobs require any of the fo
 + more than 4 vCPUs
 + more than 30 gibibytes \(GiB\) of memory
 + a GPU
-+ Arm\-based AWS Graviton CPU
 + a custom Amazon Machine Image \(AMI\)
 + any of the [linuxParameters](job_definition_parameters.md#ContainerProperties-linuxParameters) parameters
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

AWS Fargate can be used with Graviton CPUs.
https://aws.amazon.com/about-aws/whats-new/2021/11/aws-fargate-amazon-ecs-aws-graviton2-processors/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
