### PR TITLE
Change the default ebs devicename

### DIFF
--- a/doc_source/launch-templates.md
+++ b/doc_source/launch-templates.md
@@ -13,7 +13,7 @@ You must create a launch template before you can associate it with a compute env
     "LaunchTemplateData": {
         "BlockDeviceMappings": [
             {
-                "DeviceName": "/dev/xvdcz",
+                "DeviceName": "/dev/xvda",
                 "Ebs": {
                     "Encrypted": true,
                     "VolumeSize": 100,


### PR DESCRIPTION
Was trying to use this on a normal Amazon Linux 2 AMI, but looks like the default DeviceName has been changed.

*Issue #, if available:*

*Description of changes: changed DeviceName in documentation so the default volume can actually be increased*

attached picture of an ec2 instances default storage
![image](https://user-images.githubusercontent.com/70705252/203326555-420fc2b2-3798-45a6-beb8-109276c6b2b4.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
